### PR TITLE
Add GetDeb for Ubuntu package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ninja install
 ```
 ### Distro packages
 * [Arch linux](https://aur4.archlinux.org/packages/gnome-twitch-git/)
+* [Ubuntu](http://www.getdeb.net/app/GNOME%20Twitch)
 
 ## Screenshots
 ![](/data/screenshots/scrot_streams.png?raw=true)


### PR DESCRIPTION
Just published a package of ubuntu-twitch on the Ubuntu software site GetDeb.net.

It is available for Ubuntu 15.04.