### PR TITLE
Add missing file to POTFILES

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,5 @@
 data/ui/gt-win.ui
 data/ui/app-menu.ui
 data/ui/gt-settings-dlg.ui
+data/ui/gt-player-header-bar.ui
 src/gt-win.c


### PR DESCRIPTION
Autoreconf fails if the file containing translations is missing.

Error:
The following files contain translations and are currently not in use. Please
consider adding these to the POTFILES.in file, located in the po/ directory.

data/ui/gt-player-header-bar.ui