### PR TITLE
PKGBUILD: Remove build directory and early meson options.

### DIFF
--- a/data/packages/pacman/gnome-twitch-git/PKGBUILD
+++ b/data/packages/pacman/gnome-twitch-git/PKGBUILD
@@ -23,9 +23,10 @@ pkgver()
 build()
 {
     cd "$pkgname"
+    rm -rf build
     mkdir build
-    meson . build
     cd build
+    meson ..
     ninja
 }
 

--- a/data/packages/pacman/gnome-twitch-git/PKGBUILD
+++ b/data/packages/pacman/gnome-twitch-git/PKGBUILD
@@ -26,14 +26,12 @@ build()
     rm -rf build
     mkdir build
     cd build
-    meson ..
+    meson --prefix /usr --buildtype release ..
     ninja
 }
 
 package()
 {
     cd "$pkgname"/build
-    mesonconf -Dprefix=/usr 
-    mesonconf -Dtype=release
     DESTDIR="$pkgdir" ninja install
 }

--- a/data/packages/pacman/gnome-twitch/PKGBUILD
+++ b/data/packages/pacman/gnome-twitch/PKGBUILD
@@ -20,7 +20,7 @@ build()
     rm -rf build
     mkdir build
     cd build
-    meson ..
+    meson --prefix /usr --buildtype release ..
     ninja
 }
 
@@ -28,7 +28,5 @@ package()
 {
     cd "${pkgname}-${pkgver}"
     cd build
-    mesonconf -Dprefix=/usr 
-    mesonconf -Dtype=release
     DESTDIR="$pkgdir" ninja install
 }

--- a/data/packages/pacman/gnome-twitch/PKGBUILD
+++ b/data/packages/pacman/gnome-twitch/PKGBUILD
@@ -17,9 +17,10 @@ md5sums=('1047adaf29d2c948b68162d129a19fed')
 build()
 {
     cd "${pkgname}-${pkgver}"
+    rm -rf build
     mkdir build
-    meson . build
     cd build
+    meson ..
     ninja
 }
 


### PR DESCRIPTION
Some programs like pacaur + makepkg do not remove the build directory prior to building anew. Fix this in the PKGBUILD files. Additionally move meson options to build() function.