### PR TITLE
Let only the spacebar pause the video.

### DIFF
--- a/src/gt-win.c
+++ b/src/gt-win.c
@@ -160,7 +160,7 @@ key_press_cb(GtkWidget* widget,
 
     g_object_get(priv->player, "playing", &playing, NULL);
 
-    if (evt->keyval & GDK_KEY_space)
+    if (evt->keyval == GDK_KEY_space)
     {
         if (MAIN_VISIBLE_CHILD == priv->player)
         {
@@ -170,7 +170,7 @@ key_press_cb(GtkWidget* widget,
                 gt_player_play(GT_PLAYER(priv->player));
         }
     }
-    else if (evt->keyval & GDK_KEY_Escape)
+    else if (evt->keyval == GDK_KEY_Escape)
     {
         if (MAIN_VISIBLE_CHILD == priv->player)
             if (priv->fullscreen)


### PR DESCRIPTION
Currently most keys on the keyboard pauses the video. I believe It was the author's intention
that only the spacebar paused the video.