### PR TITLE
Inhibit screensaver during playback.

### DIFF
--- a/src/gt-player-clutter.c
+++ b/src/gt-player-clutter.c
@@ -28,6 +28,8 @@ typedef struct
     gchar* current_uri;
 
     GtWin* win; // Save a reference
+
+    guint inhibitor_cookie;
 } GtPlayerClutterPrivate;
 
 static void gt_player_init(GtPlayerInterface* player);
@@ -91,6 +93,11 @@ play(GtPlayer* player)
 
     priv->playing = TRUE;
     g_object_notify_by_pspec(G_OBJECT(self), props[PROP_PLAYING]);
+
+    priv->inhibitor_cookie = gtk_application_inhibit(GTK_APPLICATION(main_app),
+                                                     GTK_WINDOW(priv->win),
+                                                     GTK_APPLICATION_INHIBIT_IDLE,
+                                                     "Displaying a stream");
 }
 
 static void
@@ -104,6 +111,9 @@ stop(GtPlayer* player)
 
     priv->playing = FALSE;
     g_object_notify_by_pspec(G_OBJECT(self), props[PROP_PLAYING]);
+
+    gtk_application_uninhibit(GTK_APPLICATION(main_app), priv->inhibitor_cookie);
+    priv->inhibitor_cookie = 0;
 }
 
 static void


### PR DESCRIPTION
Hi,

I created a small patch to prevent the screensaver from starting when watching a stream. Totem and Epiphany work in a similar way.