### PR TITLE
Fixed spelling error: unkown -> unknown

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -58,7 +58,7 @@ gt_log(const gchar* domain,
             level = "All";
             break;
         default:
-            level = "Unkown";
+            level = "Unknown";
             break;
     }
 


### PR DESCRIPTION
There is a spelling error in src/main.c.
This commit fixes that.