### PR TITLE
Fixed desktop file

### DIFF
--- a/data/com.gnome-twitch.app.desktop
+++ b/data/com.gnome-twitch.app.desktop
@@ -3,4 +3,5 @@ Type=Application
 Name=GNOME Twitch
 Exec=gnome-twitch
 Icon=gnome-twitch
-Categories=GTK;GNOME;AudioVideo;Player;Video
+Categories=GTK;GNOME;AudioVideo;Player;Video;
+Keywords=stream;video;twitch;live;games;


### PR DESCRIPTION
According to the desktop file specification, a trailing semicolon after lists of values is optional, yet some verification tools will warn about it if it is missing.

I also added a "Keywords" entry, since lintian (a tool used in Debian to automatically check packages) recommends to add this.