### PR TITLE
Fix a few build warnings

### DIFF
--- a/print_git_version.sh
+++ b/print_git_version.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-if [ "$(git rev-parse --is-inside-work-tree 2> /dev/null)" == "true" ]; then
+if test "$(git rev-parse --is-inside-work-tree 2> /dev/null)" = "true"; then
     printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
 else
     exit 1

--- a/src/gt-enums.c
+++ b/src/gt-enums.c
@@ -12,7 +12,7 @@ static const GEnumValue gt_twitch_stream_quality_enum_values[] =
 GType
 gt_twitch_stream_quality_get_type()
 {
-    static GType type = NULL;
+    static GType type = 0;
 
     if (!type)
         type = g_enum_register_static("GtTwitchStreamQuality", gt_twitch_stream_quality_enum_values);

--- a/src/gt-win.c
+++ b/src/gt-win.c
@@ -300,16 +300,6 @@ window_state_cb(GtkWidget* widget,
 }
 
 static void
-show_error_message(GtWin* self, const gchar* msg)
-{
-    GtWinPrivate* priv = gt_win_get_instance_private(self);
-
-    gtk_label_set_text(GTK_LABEL(priv->info_label), msg);
-    gtk_info_bar_set_message_type(GTK_INFO_BAR(priv->info_bar), GTK_MESSAGE_WARNING);
-    gtk_revealer_set_reveal_child(GTK_REVEALER(priv->info_revealer), TRUE);
-}
-
-static void
 finalize(GObject* object)
 {
     GtWin* self = (GtWin*) object;


### PR DESCRIPTION
This removes two build warnings when using gcc 5 and a shell error if /bin/sh is not a bash.