### PR TITLE
Extend keyboard support for search and fullscreen

### DIFF
--- a/data/ui/app-menu.ui
+++ b/data/ui/app-menu.ui
@@ -19,6 +19,7 @@
       <item>
         <attribute name="label" translatable="yes">Quit</attribute>
         <attribute name="action">app.quit</attribute>
+        <attribute name="accel">&lt;Ctrl&gt;Q</attribute>
       </item>
     </section>
   </menu>

--- a/src/gt-browse-header-bar.c
+++ b/src/gt-browse-header-bar.c
@@ -244,3 +244,20 @@ gt_browse_header_bar_init(GtBrowseHeaderBar* self)
 
     gtk_widget_init_template(GTK_WIDGET(self));
 }
+
+void
+gt_browse_header_bar_stop_search(GtBrowseHeaderBar* self)
+{
+    GtBrowseHeaderBarPrivate* priv = gt_browse_header_bar_get_instance_private(self);
+
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(priv->search_button), FALSE);
+}
+
+void
+gt_browse_header_bar_toggle_search(GtBrowseHeaderBar* self)
+{
+    GtBrowseHeaderBarPrivate* priv = gt_browse_header_bar_get_instance_private(self);
+    gboolean active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->search_button));
+
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(priv->search_button), !active);
+}

--- a/src/gt-browse-header-bar.h
+++ b/src/gt-browse-header-bar.h
@@ -16,6 +16,8 @@ struct _GtBrowseHeaderBar
 
 GtBrowseHeaderBar* gt_browse_header_bar_new(void);
 void gt_browse_header_bar_stop_search(GtBrowseHeaderBar* self);
+void gt_browse_header_bar_toggle_search(GtBrowseHeaderBar* self);
+gboolean gt_browse_header_bar_handle_event(GtBrowseHeaderBar* self, GdkEvent* event);
 
 G_END_DECLS
 

--- a/src/gt-channels-view.c
+++ b/src/gt-channels-view.c
@@ -94,7 +94,7 @@ search_changed_cb(GtkEditable* edit,
 
     const gchar* query = gtk_entry_get_text(GTK_ENTRY(edit));
 
-    gt_channels_container_set_filter_query(VISIBLE_CONTAINER, query);
+    gt_channels_container_set_filter_query(GT_CHANNELS_CONTAINER(priv->search_container), query);
 }
 
 static void
@@ -187,4 +187,12 @@ gt_channels_view_show_type(GtChannelsView* self, GtChannelsContainerType type)
     }
 
     g_object_notify_by_pspec(G_OBJECT(self), props[PROP_SHOWING_TOP_CHANNELS]);
+}
+
+gboolean
+gt_channels_view_handle_event(GtChannelsView* self, GdkEvent* event)
+{
+    GtChannelsViewPrivate* priv = gt_channels_view_get_instance_private(self);
+
+    return gtk_search_bar_handle_event(GTK_SEARCH_BAR(priv->search_bar), event);
 }

--- a/src/gt-channels-view.h
+++ b/src/gt-channels-view.h
@@ -19,6 +19,7 @@ struct _GtChannelsView
 GtChannelsView* gt_channels_view_new(void);
 void gt_channels_view_refresh(GtChannelsView* self);
 void gt_channels_view_show_type(GtChannelsView* self, GtChannelsContainerType type);
+gboolean gt_channels_view_handle_event(GtChannelsView* self, GdkEvent* event);
 
 G_END_DECLS
 

--- a/src/gt-favourites-view.c
+++ b/src/gt-favourites-view.c
@@ -126,3 +126,11 @@ gt_favourites_view_init(GtFavouritesView* self)
                            priv->search_bar, "search-mode-enabled",
                            G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE | G_BINDING_BIDIRECTIONAL);
 }
+
+gboolean
+gt_favourites_view_handle_event(GtFavouritesView* self, GdkEvent* event)
+{
+    GtFavouritesViewPrivate* priv = gt_favourites_view_get_instance_private(self);
+
+    return gtk_search_bar_handle_event(GTK_SEARCH_BAR(priv->search_bar), event);
+}

--- a/src/gt-favourites-view.h
+++ b/src/gt-favourites-view.h
@@ -14,7 +14,7 @@ struct _GtFavouritesView
     GtkBox parent_instance;
 };
 
-GtFavouritesView* gt_favourites_view_new(void);
+gboolean gt_favourites_view_handle_event(GtFavouritesView* self, GdkEvent* event);
 
 G_END_DECLS
 

--- a/src/gt-games-view.c
+++ b/src/gt-games-view.c
@@ -241,3 +241,11 @@ gt_games_view_show_type(GtGamesView* self, gint type)
     g_object_notify_by_pspec(G_OBJECT(self), props[PROP_SHOWING_TOP_GAMES]);
     g_object_notify_by_pspec(G_OBJECT(self), props[PROP_SHOWING_GAME_CHANNELS]);
 }
+
+gboolean
+gt_games_view_handle_event(GtGamesView* self, GdkEvent* event)
+{
+    GtGamesViewPrivate* priv = gt_games_view_get_instance_private(self);
+
+    return gtk_search_bar_handle_event(GTK_SEARCH_BAR(priv->search_bar), event);
+}

--- a/src/gt-games-view.h
+++ b/src/gt-games-view.h
@@ -18,6 +18,7 @@ struct _GtGamesView
 GtGamesView* gt_games_view_new(void);
 void gt_games_view_refresh(GtGamesView* self);
 void gt_games_view_show_type(GtGamesView* self, gint type);
+gboolean gt_games_view_handle_event(GtGamesView* self, GdkEvent* event);
 
 G_END_DECLS
 

--- a/src/gt-win.c
+++ b/src/gt-win.c
@@ -217,12 +217,7 @@ key_press_cb(GtkWidget* widget,
 
     g_object_get(self->player, "playing", &playing, NULL);
 
-    if (evt->keyval == GDK_KEY_q && (evt->state & modifiers) == GDK_CONTROL_MASK)
-    {
-        action = g_action_map_lookup_action(G_ACTION_MAP(main_app), "quit");
-        g_action_activate(action, NULL);
-    }
-    else if (MAIN_VISIBLE_CHILD == self->player)
+    if (MAIN_VISIBLE_CHILD == self->player)
     {
         if (evt->keyval == GDK_KEY_space)
         {

--- a/src/gt-win.c
+++ b/src/gt-win.c
@@ -211,25 +211,61 @@ key_press_cb(GtkWidget* widget,
 {
     GtWin* self = GT_WIN(udata);
     GtWinPrivate* priv = gt_win_get_instance_private(self);
+    GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask();
     gboolean playing;
+    GAction *action;
 
     g_object_get(self->player, "playing", &playing, NULL);
 
-    if (evt->keyval == GDK_KEY_space)
+    if (evt->keyval == GDK_KEY_q && (evt->state & modifiers) == GDK_CONTROL_MASK)
     {
-        if (MAIN_VISIBLE_CHILD == self->player)
+        action = g_action_map_lookup_action(G_ACTION_MAP(main_app), "quit");
+        g_action_activate(action, NULL);
+    }
+    else if (MAIN_VISIBLE_CHILD == self->player)
+    {
+        if (evt->keyval == GDK_KEY_space)
         {
             if (playing)
                 gt_player_stop(GT_PLAYER(self->player));
             else
                 gt_player_play(GT_PLAYER(self->player));
         }
-    }
-    else if (evt->keyval == GDK_KEY_Escape)
-    {
-        if (MAIN_VISIBLE_CHILD == self->player)
+        else if (evt->keyval == GDK_KEY_Escape)
+        {
             if (priv->fullscreen)
                 gtk_window_unfullscreen(GTK_WINDOW(self));
+            else
+            {
+                action = g_action_map_lookup_action(G_ACTION_MAP(self), "close_player");
+                g_action_activate(action, NULL);
+            }
+        }
+        else if (evt->keyval == GDK_KEY_f)
+        {
+            if (priv->fullscreen)
+                gtk_window_unfullscreen(GTK_WINDOW(self));
+            else
+                gtk_window_fullscreen(GTK_WINDOW(self));
+        }
+    }
+    else
+    {
+        if (evt->keyval == GDK_KEY_Escape)
+            gt_browse_header_bar_stop_search(GT_BROWSE_HEADER_BAR(priv->browse_header_bar));
+        else if (evt->keyval == GDK_KEY_f && (evt->state & modifiers) == GDK_CONTROL_MASK)
+            gt_browse_header_bar_toggle_search(GT_BROWSE_HEADER_BAR(priv->browse_header_bar));
+        else
+        {
+            GtkWidget *view = gtk_stack_get_visible_child(GTK_STACK(priv->browse_stack));
+
+            if (view == priv->channels_view)
+                gt_channels_view_handle_event(GT_CHANNELS_VIEW(priv->channels_view), (GdkEvent *)evt);
+            else if (view == priv->games_view)
+                gt_games_view_handle_event(GT_GAMES_VIEW(priv->games_view), (GdkEvent *)evt);
+            else if (view == priv->favourites_view)
+                gt_favourites_view_handle_event(GT_FAVOURITES_VIEW(priv->favourites_view), (GdkEvent *)evt);
+        }
     }
 
     return FALSE;


### PR DESCRIPTION
This patch allows to search in the channels, favourites, or games views,
just by starting to type. This should fix issue #8. The search bar can be
toggled by pressing Ctrl+F or dismissed by pressing Escape.

Pressing Escape in the player view exits fullscreen or closes the player
and returns to the browse views if windowed. The F key can be used to
toggle fullscreen.

Ctrl+Q immediately quits the application.