### PR TITLE
Improve auto-update functionality

### DIFF
--- a/data/gnome-twitch.gschema.xml
+++ b/data/gnome-twitch.gschema.xml
@@ -16,6 +16,12 @@
       <summary>Default quality</summary>
       <description>Default quality selected when opening a stream</description>
     </key>
+    <key name="auto-update-interval" type="u">
+      <range min="60"/>
+      <default>120</default>
+      <summary>Auto-Update interval</summary>
+      <description>Interval (in seconds) between automatic update for favourite channels</description>
+    </key>
     <key name="volume" type="d">
       <range min="0.0" max="1.0"/>
       <default>0.3</default>

--- a/src/gt-app.c
+++ b/src/gt-app.c
@@ -130,9 +130,9 @@ activate(GApplication* app)
 }
 
 static void
-gt_app_prefer_dark_theme_changed_cb(GSettings *settings,
+gt_app_prefer_dark_theme_changed_cb(GSettings* settings,
                                     const char* key,
-                                    GtkSettings *gtk_settings)
+                                    GtkSettings* gtk_settings)
 {
     gboolean prefer_dark_theme = g_settings_get_boolean(settings, key);
 
@@ -147,7 +147,7 @@ startup(GApplication* app)
 {
     GtApp* self = GT_APP(app);
     GtAppPrivate* priv = gt_app_get_instance_private(self);
-    GtkSettings *gtk_settings = gtk_settings_get_default();
+    GtkSettings* gtk_settings = gtk_settings_get_default();
 
     self->fav_mgr = gt_favourites_manager_new();
     gt_favourites_manager_load(self->fav_mgr);

--- a/src/gt-browse-header-bar.c
+++ b/src/gt-browse-header-bar.c
@@ -118,22 +118,6 @@ set_property(GObject*      obj,
 }
 
 static void
-show_refresh_button_cb(GObject* source,
-                       GParamSpec* pspec,
-                       gpointer udata)
-{
-    GtBrowseHeaderBar* self = GT_BROWSE_HEADER_BAR(udata);
-    GtBrowseHeaderBarPrivate* priv = gt_browse_header_bar_get_instance_private(self);
-    GtkWidget* view = NULL;
-     
-    g_object_get(GT_WIN_TOPLEVEL(self), "visible-view", &view, NULL);
-
-    gtk_revealer_set_reveal_child(GTK_REVEALER(priv->refresh_revealer), view != GTK_WIDGET(priv->favourites_view));
-
-    g_object_unref(view);
-}
-
-static void
 search_active_cb(GObject* source,
                  GParamSpec* pspec,
                  gpointer udata)
@@ -191,7 +175,6 @@ realize(GtkWidget* widget,
 
     g_signal_connect(GT_WIN_TOPLEVEL(widget), "notify::visible-view", G_CALLBACK(visible_view_cb), self);
     g_signal_connect(GT_WIN_TOPLEVEL(widget), "notify::visible-view", G_CALLBACK(show_nav_buttons_cb), self);
-    g_signal_connect(GT_WIN_TOPLEVEL(widget), "notify::visible-view", G_CALLBACK(show_refresh_button_cb), self);
     g_signal_connect(priv->games_view, "notify::showing-game-channels", G_CALLBACK(show_nav_buttons_cb), self);
     g_signal_connect(priv->search_button, "notify::active", G_CALLBACK(search_active_cb), self);
 }

--- a/src/gt-channel.h
+++ b/src/gt-channel.h
@@ -21,6 +21,7 @@ void gt_channel_toggle_favourited(GtChannel* self);
 void gt_channel_free_list(GList* list);
 gboolean gt_channel_compare(GtChannel* self, gpointer other);
 const gchar* gt_channel_get_name(GtChannel* self);
+void gt_channel_update(GtChannel* self);
 
 G_END_DECLS
 

--- a/src/gt-channels-container-favourite.c
+++ b/src/gt-channels-container-favourite.c
@@ -35,10 +35,7 @@ static void
 refresh(GtChannelsContainer* container)
 {
     for (GList* l = main_app->fav_mgr->favourite_channels; l != NULL; l = l->next)
-    {
-        g_object_set(G_OBJECT(l->data), "auto-update", FALSE, NULL);
-        g_object_set(G_OBJECT(l->data), "auto-update", TRUE, NULL);
-    }
+        gt_channel_update(GT_CHANNEL(l->data));
 }
 
 static void

--- a/src/gt-channels-container-favourite.c
+++ b/src/gt-channels-container-favourite.c
@@ -34,8 +34,7 @@ bottom_edge_reached(GtChannelsContainer* container)
 static void
 refresh(GtChannelsContainer* container)
 {
-    for (GList* l = main_app->fav_mgr->favourite_channels; l != NULL; l = l->next)
-        gt_channel_update(GT_CHANNEL(l->data));
+    gt_favourites_manager_update(main_app->fav_mgr);
 }
 
 static void

--- a/src/gt-channels-container-favourite.c
+++ b/src/gt-channels-container-favourite.c
@@ -34,7 +34,11 @@ bottom_edge_reached(GtChannelsContainer* container)
 static void
 refresh(GtChannelsContainer* container)
 {
-    //TODO: Force favourites refresh
+    for (GList* l = main_app->fav_mgr->favourite_channels; l != NULL; l = l->next)
+    {
+        g_object_set(G_OBJECT(l->data), "auto-update", FALSE, NULL);
+        g_object_set(G_OBJECT(l->data), "auto-update", TRUE, NULL);
+    }
 }
 
 static void

--- a/src/gt-favourites-manager.c
+++ b/src/gt-favourites-manager.c
@@ -238,10 +238,8 @@ gt_favourites_manager_load(GtFavouritesManager* self)
         GtChannel* chan = GT_CHANNEL(json_gobject_deserialize(GT_TYPE_CHANNEL, l->data));
         self->favourite_channels = g_list_append(self->favourite_channels, chan);
         g_signal_handlers_block_by_func(chan, channel_favourited_cb, self);
-        g_object_set(chan, 
-                     "auto-update", TRUE, 
-                     "favourited", TRUE,
-                     NULL);
+        g_object_set(chan, "favourited", TRUE, NULL);
+        gt_channel_update(chan);
         g_signal_handlers_unblock_by_func(chan, channel_favourited_cb, self);
 
         g_signal_connect(chan, "notify::updating", G_CALLBACK(oneshot_updating_cb), self);

--- a/src/gt-favourites-manager.c
+++ b/src/gt-favourites-manager.c
@@ -140,6 +140,17 @@ auto_update_cb(GtFavouritesManager* self)
 }
 
 static void
+auto_update_interval_changed_cb(GSettings* settings,
+                           const gchar* key,
+                           GtFavouritesManager* self)
+{
+    GtFavouritesManagerPrivate* priv = gt_favourites_manager_get_instance_private(self);
+
+    priv->auto_update_interval = g_settings_get_uint(settings, key);
+    gt_favourites_manager_update(self);
+}
+
+static void
 shutdown_cb(GApplication* app,
             gpointer udata)
 {
@@ -222,7 +233,11 @@ gt_favourites_manager_init(GtFavouritesManager* self)
 {
     GtFavouritesManagerPrivate* priv = gt_favourites_manager_get_instance_private(self);
 
-    priv->auto_update_interval = 120;
+    auto_update_interval_changed_cb(main_app->settings, "auto-update-interval", self);
+    g_signal_connect(main_app->settings,
+                     "changed::auto-update-interval",
+                     G_CALLBACK(auto_update_interval_changed_cb),
+                     self);
 
     g_signal_connect(main_app, "shutdown", G_CALLBACK(shutdown_cb), self);
 }

--- a/src/gt-favourites-manager.h
+++ b/src/gt-favourites-manager.h
@@ -23,6 +23,7 @@ void gt_favourites_manager_load(GtFavouritesManager* self);
 void gt_favourites_manager_save(GtFavouritesManager* self);
 gboolean gt_favourites_manager_is_channel_favourited(GtFavouritesManager* self, GtChannel* chan);
 void gt_favourites_manager_attach_to_channel(GtFavouritesManager* self, GtChannel* chan);
+void gt_favourites_manager_update(GtFavouritesManager* self);
 
 G_END_DECLS
 

--- a/src/gt-favourites-view.c
+++ b/src/gt-favourites-view.c
@@ -126,3 +126,11 @@ gt_favourites_view_init(GtFavouritesView* self)
                            priv->search_bar, "search-mode-enabled",
                            G_BINDING_DEFAULT | G_BINDING_SYNC_CREATE | G_BINDING_BIDIRECTIONAL);
 }
+
+void
+gt_favourites_view_refresh(GtFavouritesView* self)
+{
+    GtFavouritesViewPrivate* priv = gt_favourites_view_get_instance_private(self);
+
+    gt_channels_container_refresh(GT_CHANNELS_CONTAINER(priv->favourite_container));
+}

--- a/src/gt-favourites-view.h
+++ b/src/gt-favourites-view.h
@@ -15,6 +15,7 @@ struct _GtFavouritesView
 };
 
 GtFavouritesView* gt_favourites_view_new(void);
+void gt_favourites_view_refresh(GtFavouritesView* self);
 
 G_END_DECLS
 

--- a/src/gt-win.c
+++ b/src/gt-win.c
@@ -186,6 +186,8 @@ refresh_view_cb(GSimpleAction* action,
 
     if (gtk_stack_get_visible_child(GTK_STACK(priv->browse_stack)) == priv->channels_view)
         gt_channels_view_refresh(GT_CHANNELS_VIEW(priv->channels_view));
+    else if (gtk_stack_get_visible_child(GTK_STACK(priv->browse_stack)) == priv->favourites_view)
+        gt_favourites_view_refresh(GT_FAVOURITES_VIEW(priv->favourites_view));
     else if (gtk_stack_get_visible_child(GTK_STACK(priv->browse_stack)) == priv->games_view)
         gt_games_view_refresh(GT_GAMES_VIEW(priv->games_view));
 }


### PR DESCRIPTION
This pull request might be a little ambitious for my level of experience.

Commit 0f6c82d fixes an unrelated coding style inconsistency I introduced in the past.

Commits f34d88b and 896cdc6 address the inability to manually refresh the Favourites View. This removes one of the TODOs in the source code. It feels sub-optimal though, because there isn't a way to externally initiate an update for a GtChannel object.

In order to improve it, my idea was to make the make the update() function public and remove all auto-update logic from GtChannel. This is done in commit 00e38b6. Then, the functionality is added to GtFavouritesManager with commit 13271dc. I thought that this was the only relevant place, given that auto-update is limited to favourited channels.

Lastly, commit b505392 makes the update interval configurable and removes another TODO from the code. The option is not exposed through the UI, but it can be changed at run-time with gsettings.