### PR TITLE
Added Debian to the list of distros containing gnome-twitch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ninja install
 ### Distro packages
 * [Arch linux](https://aur4.archlinux.org/packages/gnome-twitch/)
 * [Arch linux (git)](https://aur4.archlinux.org/packages/gnome-twitch-git/)
+* [Debian] (https://tracker.debian.org/pkg/gnome-twitch/)
 * [Fedora](https://copr.fedoraproject.org/coprs/ippytraxx/gnome-twitch/) (You will need to install gstreamer1-libav from RPMFusion)
 * [Ubuntu (PPA)](https://launchpad.net/~ippytraxx/+archive/ubuntu/gnome-twitch/) (You will need to install the ubuntu-restricted-extras for the h264 decoder)
 * [Ubuntu (courtesy of GetDeb.net)](http://www.getdeb.net/app/GNOME%20Twitch) (Same requirements as the PPA)


### PR DESCRIPTION
Since gnome-twitch has made it into Debian some time ago (I maintain the package there), I added it to the list of distros in the Readme.

While we're at it: It might be a little early for this "reminder", but consider that the version of gnome-twitch in Debian testing at the time of the freeze will be the version that goes into the next stable. Also, new versions need a few days to transition from unstable (where they are uploaded) to testing (if everything works smoothly, i.e. no dependency issues or anything). According to https://wiki.debian.org/DebianStretch the transition freeze starts on 2016-09-05, so the packaging work should be finished in summer 2016.
The reason I'm saying this is because the stable release will be around for a long time and people using it will report their bugs against that version, so you might be interested to get a particular version of gnome-twitch out that you are comfortable with supporting over a longer period of time.

Also, it  seems that gnome-twitch will automatically be included in the next Ubuntu release, since they just pull their packages from unstable. I don't have anything to do with Ubuntu, so I don't know if they have a freeze before their release where they stop pulling from Debian or what their policies are on uploading new versions after the release. Their next release seems to be on 2016-04-21.