### PR TITLE
Ensure that the timeout source is removed.

### DIFF
--- a/src/gt-player-clutter.c
+++ b/src/gt-player-clutter.c
@@ -476,6 +476,9 @@ finalize(GObject* object)
     GtPlayerClutter* self = (GtPlayerClutter*) object;
     GtPlayerClutterPrivate* priv = gt_player_clutter_get_instance_private(self);
 
+    if (priv->cursor_hiding_timeout_id != 0)
+        g_source_remove(priv->cursor_hiding_timeout_id);
+
     G_OBJECT_CLASS(gt_player_clutter_parent_class)->finalize(object);
 }
 

--- a/src/gt-player-clutter.c
+++ b/src/gt-player-clutter.c
@@ -476,8 +476,7 @@ finalize(GObject* object)
     GtPlayerClutter* self = (GtPlayerClutter*) object;
     GtPlayerClutterPrivate* priv = gt_player_clutter_get_instance_private(self);
 
-    if (priv->cursor_hiding_timeout_id != 0)
-        g_source_remove(priv->cursor_hiding_timeout_id);
+    unschedule_cursor_hiding(self);
 
     G_OBJECT_CLASS(gt_player_clutter_parent_class)->finalize(object);
 }


### PR DESCRIPTION
This was omitted in pull request #73. I also found a bug that occurred when having multiple windows, but it seems related to GTK+. See [this](https://mail.gnome.org/archives/clutter-list/2016-February/msg00006.html) thread.