### PR TITLE
Cache channel offline banners and game box art

### DIFF
--- a/src/gt-app.c
+++ b/src/gt-app.c
@@ -6,7 +6,6 @@
 #include <string.h>
 #include <json-glib/json-glib.h>
 
-#define DATA_DIR g_build_filename(g_get_user_data_dir(), "gnome-twitch", NULL)
 #define CHANNEL_SETTINGS_FILE g_build_filename(g_get_user_data_dir(), "gnome-twitch", "channel_settings.json", NULL);
 
 typedef struct
@@ -180,15 +179,25 @@ oauth_token_set_cb(GObject* src,
 static void
 init_dirs()
 {
-    gchar* fp = DATA_DIR;
+    gchar* fp;
+    int err;
 
-    int err = g_mkdir(fp, 0777);
-
+    fp = g_build_filename(g_get_user_data_dir(), "gnome-twitch", NULL);
+    err = g_mkdir_with_parents(fp, 0777);
     if (err != 0 && g_file_error_from_errno(errno) != G_FILE_ERROR_EXIST)
-    {
-        g_warning("{GtApp} Error creating data dir");
-    }
+        g_warning("{GtApp} Error creating data directory");
+    g_free(fp);
 
+    fp = g_build_filename(g_get_user_cache_dir(), "gnome-twitch", "channels", NULL);
+    err = g_mkdir_with_parents(fp, 0777);
+    if (err != 0 && g_file_error_from_errno(errno) != G_FILE_ERROR_EXIST)
+        g_warning("{GtApp} Error creating channel cache directory");
+    g_free(fp);
+
+    fp = g_build_filename(g_get_user_cache_dir(), "gnome-twitch", "games", NULL);
+    err = g_mkdir_with_parents(fp, 0777);
+    if (err != 0 && g_file_error_from_errno(errno) != G_FILE_ERROR_EXIST)
+        g_warning("{GtApp} Error creating game cache directory");
     g_free(fp);
 }
 

--- a/src/gt-channel.c
+++ b/src/gt-channel.c
@@ -222,8 +222,8 @@ update_preview(GtChannel* self)
 
     if (priv->online)
     {
-        gt_twitch_download_picture_async(main_app->twitch, priv->preview_url, priv->cancel, 
-                                         (GAsyncReadyCallback) download_picture_cb, self); 
+        gt_twitch_download_picture_async(main_app->twitch, priv->preview_url, 0, priv->cancel,
+                                         (GAsyncReadyCallback) download_picture_cb, self);
     }
     else
     {
@@ -240,7 +240,7 @@ update_preview(GtChannel* self)
             }
 
             if (!priv->preview)
-                gt_twitch_download_picture_async(main_app->twitch, priv->video_banner_url, priv->cancel,
+                gt_twitch_download_picture_async(main_app->twitch, priv->video_banner_url, 0, priv->cancel,
                                                  (GAsyncReadyCallback) download_picture_cb, self);
             else
             {

--- a/src/gt-channel.c
+++ b/src/gt-channel.c
@@ -275,6 +275,7 @@ finalize(GObject* object)
     g_free(priv->display_name);
     g_free(priv->game);
     g_free(priv->status);
+    g_free(priv->cache_filename);
 
     if (priv->stream_started_time)
         g_date_time_unref(priv->stream_started_time);

--- a/src/gt-channel.c
+++ b/src/gt-channel.c
@@ -239,7 +239,7 @@ update_preview(GtChannel* self)
 
             if (ret)
                 g_info("{GtChannel} Cache miss for channel '%s'", priv->name);
-            else if (g_date_time_to_unix(now) - file_stat.st_mtim.tv_sec > 604800)
+            else if (g_date_time_to_unix(now) - file_stat.st_mtim.tv_sec > 604800 + g_random_int_range(0, 604800))
                 g_info("{GtChannel} Stale cache for channel '%s'", priv->name);
             else
             {

--- a/src/gt-twitch.c
+++ b/src/gt-twitch.c
@@ -3,7 +3,7 @@
 #include "gt-game.h"
 #include "utils.h"
 #include <libsoup/soup.h>
-#include <glib/gprintf.h>
+#include <glib/gstdio.h>
 #include <glib.h>
 #include <json-glib/json-glib.h>
 #include <string.h>
@@ -319,6 +319,12 @@ parse_stream(GtTwitch* self, JsonReader* reader, GtChannelRawData* data)
 static void
 parse_game(GtTwitch* self, JsonReader* reader, GtGameRawData* data)
 {
+    gchar* id;
+    gchar* filename;
+    GStatBuf file_stat;
+    GDateTime* now;
+    int ret;
+
     json_reader_read_member(reader, "_id");
     data->id = json_reader_get_int_value(reader);
     json_reader_end_member(reader);
@@ -327,12 +333,36 @@ parse_game(GtTwitch* self, JsonReader* reader, GtGameRawData* data)
     data->name = g_strdup(json_reader_get_string_value(reader));
     json_reader_end_member(reader);
 
-    json_reader_read_member(reader, "box");
+    id = g_strdup_printf("%ld", data->id);
+    filename = g_build_filename(g_get_user_cache_dir(), "gnome-twitch", "games", id, NULL);
+    ret = g_stat(filename, &file_stat);
+    now = g_date_time_new_now_utc();
 
-    json_reader_read_member(reader, "large");
-    data->preview = gt_twitch_download_picture(self, json_reader_get_string_value(reader));
-    json_reader_end_member(reader);
-    json_reader_end_member(reader);
+    if (ret)
+        g_info("{GtTwitch} Cache miss for game '%s'", data->name);
+    else if (g_date_time_to_unix(now) - file_stat.st_mtim.tv_sec > 604800)
+        g_info("{GtTwitch} Stale cache for game '%s'", data->name);
+    else
+    {
+        g_info("{GtTwitch} Cache hit for game '%s'", data->name);
+        data->preview = gdk_pixbuf_new_from_file(filename, NULL);
+    }
+
+    if (!data->preview)
+    {
+        json_reader_read_member(reader, "box");
+        json_reader_read_member(reader, "large");
+
+        data->preview = gt_twitch_download_picture(self, json_reader_get_string_value(reader));
+        gdk_pixbuf_save(data->preview, filename, "jpeg", NULL, NULL);
+
+        json_reader_end_member(reader);
+        json_reader_end_member(reader);
+    }
+
+    g_free(id);
+    g_free(filename);
+    g_date_time_unref(now);
 }
 
 GtTwitchStreamAccessToken*

--- a/src/gt-twitch.c
+++ b/src/gt-twitch.c
@@ -340,7 +340,7 @@ parse_game(GtTwitch* self, JsonReader* reader, GtGameRawData* data)
 
     if (ret)
         g_info("{GtTwitch} Cache miss for game '%s'", data->name);
-    else if (g_date_time_to_unix(now) - file_stat.st_mtim.tv_sec > 604800)
+    else if (g_date_time_to_unix(now) - file_stat.st_mtim.tv_sec > 604800 + g_random_int_range(0, 604800))
         g_info("{GtTwitch} Stale cache for game '%s'", data->name);
     else
     {

--- a/src/gt-twitch.h
+++ b/src/gt-twitch.h
@@ -123,8 +123,8 @@ void                    gt_twitch_channel_raw_data_async(GtTwitch* self, const g
 void                    gt_twitch_channel_raw_data_free(GtChannelRawData* data);
 GtGameRawData*          gt_twitch_game_raw_data(GtTwitch* self, const gchar* name);
 void                    gt_twitch_game_raw_data_free(GtGameRawData* data);
-GdkPixbuf*              gt_twitch_download_picture(GtTwitch* self, const gchar* url);
-void                    gt_twitch_download_picture_async(GtTwitch* self, const gchar* url, GCancellable* cancel, GAsyncReadyCallback cb, gpointer udata);
+GdkPixbuf*              gt_twitch_download_picture(GtTwitch* self, const gchar* url, gint64 timestamp);
+void                    gt_twitch_download_picture_async(GtTwitch* self, const gchar* url, gint64 timestamp, GCancellable* cancel, GAsyncReadyCallback cb, gpointer udata);
 GdkPixbuf*              gt_twitch_download_emote(GtTwitch* self, gint id);
 GtChatBadges*     gt_chat_badges(GtTwitch* self, const gchar* chan);
 void                    gt_chat_badges_async(GtTwitch* self, const gchar* channel, GCancellable* cancel, GAsyncReadyCallback cb, gpointer udata);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,4 +1,6 @@
 #include "utils.h"
+#include <glib/gstdio.h>
+#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -28,6 +30,33 @@ utils_container_clear(GtkContainer* cont)
     {
         gtk_container_remove(cont, GTK_WIDGET(l->data));
     }
+}
+
+gint64
+utils_timestamp_file(const gchar* filename)
+{
+    int ret;
+    GStatBuf file_stat;
+
+    ret = g_stat(filename, &file_stat);
+
+    if (ret)
+        return 0;
+
+    return file_stat.st_mtim.tv_sec;
+}
+
+gint64
+utils_timestamp_now(void)
+{
+    gint64 timestamp;
+    GDateTime* now;
+
+    now = g_date_time_new_now_utc();
+    timestamp = g_date_time_to_unix(now);
+    g_date_time_unref(now);
+
+    return timestamp;
 }
 
 void

--- a/src/utils.c
+++ b/src/utils.c
@@ -70,6 +70,19 @@ utils_pixbuf_scale_simple(GdkPixbuf** pixbuf, gint width, gint height, GdkInterp
     *pixbuf = tmp;
 }
 
+static gint64
+utils_http_full_date_to_timestamp(const char* string)
+{
+    gint64 ret;
+    SoupDate* tmp;
+
+    tmp = soup_date_new_from_string(string);
+    ret = soup_date_to_time_t(tmp);
+    soup_date_free(tmp);
+
+    return ret;
+}
+
 GdkPixbuf*
 utils_download_picture(SoupSession* soup, const gchar* url)
 {
@@ -92,6 +105,32 @@ utils_download_picture(SoupSession* soup, const gchar* url)
 
         g_input_stream_close(input, NULL, NULL);
     }
+
+    g_object_unref(msg);
+
+    return ret;
+}
+
+GdkPixbuf*
+utils_download_picture_if_newer(SoupSession* soup, const gchar* url, gint64 timestamp)
+{
+    SoupMessage* msg;
+    guint soup_status;
+    const gchar* last_modified;
+    GdkPixbuf* ret;
+
+    msg = soup_message_new(SOUP_METHOD_HEAD, url);
+    soup_status = soup_session_send_message(soup, msg);
+
+    if (SOUP_STATUS_IS_SUCCESSFUL(soup_status) &&
+        (last_modified = soup_message_headers_get_one(msg->response_headers, "Last-Modified")) != NULL &&
+        utils_http_full_date_to_timestamp(last_modified) < timestamp)
+    {
+        g_info("{Utils} No new content at url '%s'", url);
+        ret = NULL;
+    }
+    else
+        ret = utils_download_picture(soup, url);
 
     g_object_unref(msg);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -11,6 +11,8 @@
 gpointer utils_value_ref_sink_object(const GValue* val);
 gchar* utils_value_dup_string_allow_null(const GValue* val);
 void utils_container_clear(GtkContainer* cont);
+gint64 utils_timestamp_file(const gchar* filename);
+gint64 utils_timestamp_now(void);
 void utils_pixbuf_scale_simple(GdkPixbuf** pixbuf, gint width, gint height, GdkInterpType interp);
 GdkPixbuf* utils_download_picture(SoupSession* soup, const gchar* url);
 const gchar* utils_search_key_value_strv(gchar** strv, const gchar* key);

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,6 +15,7 @@ gint64 utils_timestamp_file(const gchar* filename);
 gint64 utils_timestamp_now(void);
 void utils_pixbuf_scale_simple(GdkPixbuf** pixbuf, gint width, gint height, GdkInterpType interp);
 GdkPixbuf* utils_download_picture(SoupSession* soup, const gchar* url);
+GdkPixbuf* utils_download_picture_if_newer(SoupSession* soup, const gchar* url, gint64 timestamp);
 const gchar* utils_search_key_value_strv(gchar** strv, const gchar* key);
 void utils_connect_mouse_hover(GtkWidget* widget);
 void utils_connect_link(GtkWidget* widget, const gchar* link);


### PR DESCRIPTION
Banners and box art change rarely. By caching them to disk, the start-up time of GNOME Twitch can be substantially improved. When I tested this, with 10 favorite channels and a hot cache, the amount of data transferred on start-up dropped from about 12 MB to just over 2 MB.

The last commit as a bit of a gimmick, but what it means is that cached images will be considered fresh for 7 to 14 days. I think that this is a reasonable lifespan.