### PR TITLE
Add man page

### DIFF
--- a/data/gnome-twitch.1
+++ b/data/gnome-twitch.1
@@ -1,0 +1,65 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" (C) Copyright 2015-2016 Tim Dengel <tim.dengel.debian@gmail.com>,
+.\"
+.TH GNOME-TWITCH 1 "April 08, 2016"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+gnome-twitch \- GNOME Twitch app for watching Twitch.tv streams without a browser or flash.
+.SH SYNOPSIS
+.B gnome-twitch
+.RI [ options ] 
+.SH DESCRIPTION
+gnome-twitch provides a GTK3 interface for viewing streams on Twitch.
+.br
+At the moment you can
+.br
+* browse popular streams,
+.br
+* browse streams by game,
+.br
+* search for streams,
+.br
+* view streams,
+.br
+* use the chat with a Twitch account,
+.br
+* change the video quality and
+.br
+* mark streams as favorites for faster access.
+.br
+More features like recording streams, VODs (Video-On-Demand), other player backends and integration of Twitch account features like following streams are planned.
+.PP
+.SH OPTIONS
+This program follows the usual GNU command line syntax, with long
+options starting with two dashes (`-').
+A summary of options is included below.
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.TP
+.B \-l, \-\-log\-level=\fILevel\fP
+Set logging level. 
+.br 
+.I Level
+can be one of the following numbers:
+.br
+0 (Critical) 
+.br
+1 (Warning) 
+.br
+2 (Message)
+.br
+3 (Info)
+.br
+4 (Debug)

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,4 @@
+install_man('gnome-twitch.1')
 install_data('com.gnome-twitch.app.desktop', install_dir : 'share/applications')
 install_data('icons/hicolor/16x16/apps/gnome-twitch.png', install_dir : 'share')
 install_data('icons/hicolor/22x22/apps/gnome-twitch.png', install_dir : 'share')


### PR DESCRIPTION
I had originally written this man page for Debian (because every executable is required to have a man page in Debian), and while working on the new package I asked myself why I didn't submit it upstream earlier, so here I am. :)

One thing I'm not sure about are the log levels, because they seem to be 
-1 (Error)
0 (Critical)
1 (Warning)
2 (Message)
3 (Info)
4 (Debug)

I didn't document the "Error" level (-1) because it seems weird, so maybe it wasn't intended to be specified by the user. It also seems to be used only once in the mpv backend (which doesn't really exist yet). But maybe it is the numbering that is wrong and Error was supposed to be 0 and so on, if that's the case I can update the PR after that is fixed.