### PR TITLE
Apply limits to the labels of the container children

### DIFF
--- a/data/ui/gt-channels-container-child.ui
+++ b/data/ui/gt-channels-container-child.ui
@@ -143,6 +143,9 @@
         <child>
           <object class="GtkLabel" id="name_label">
             <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="max-width-chars">1</property>
+            <property name="ellipsize">middle</property>
             <attributes>
               <attribute name="size" value="13000"/>
             </attributes>
@@ -151,6 +154,9 @@
         <child>
           <object class="GtkLabel" id="game_label">
             <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="max-width-chars">1</property>
+            <property name="ellipsize">middle</property>
             <attributes>
               <attribute name="size" value="10000"/>
             </attributes>

--- a/data/ui/gt-games-container-child.ui
+++ b/data/ui/gt-games-container-child.ui
@@ -57,7 +57,11 @@
           <object class="GtkLabel" id="name_label">
             <property name="visible">True</property>
             <property name="wrap">True</property>
-            <property name="max-width-chars">12</property>
+            <property name="hexpand">True</property>
+            <property name="max-width-chars">1</property>
+            <property name="ellipsize">middle</property>
+            <property name="lines">2</property>
+            <property name="justify">center</property>
             <attributes>
               <attribute name="size" value="13000"/>
             </attributes>


### PR DESCRIPTION
This happened today:

![screenshot from 2016-04-10 12-01-00](https://cloud.githubusercontent.com/assets/2452306/14409699/c60a75f0-ff23-11e5-8b34-9d03bc84e16c.jpeg)

The first commit fixes this issue for the channels container. The second one improves the current limits of the games container.