### PR TITLE
Add missing words to copyright statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,15 @@
 Enjoy Twitch on your GNU/Linux desktop.
-Copyright (C) 2015 Ippytraxx a.k.a Vincent Szolnoky <ippytraxx@installgentoo.com>
+Copyright (C) 2015-2016 Ippytraxx a.k.a Vincent Szolnoky <ippytraxx@installgentoo.com>
 
 This program is free software: you can redistribute it and/or modify
-under the terms of the GNU General Public License as published by
-Free Software Foundation, either version 3 of the License, or
-at your option) any later version.
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
-WITHOUT ANY WARRANTY; without even the implied warranty of
-or FITNESS FOR A PARTICULAR PURPOSE.  See the
-General Public License for more details.
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
There were some words missing in the copyright statement, probably lost during copy&paste. Also I updated the year.