### PR TITLE
New meson behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the hassle of flash or the web.
 
 ## Install
 ### Dependencies
-* meson >= 0.31.0 (install only)
+* meson >= 0.32.0 (install only)
 * ninja (install only)
 * gtk+-3.0 >= 3.20
 * libsoup

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,3 +1,5 @@
+i18n = import('i18n')
+
 langs = ['de', 'pl', 'pt', 'sv', 'fr', 'ru', 'sr', 'hu']
 
-gettext('gnome-twitch', languages : langs)
+i18n.gettext('gnome-twitch', languages : langs)


### PR DESCRIPTION
With meson 0.32, gnome-twitch fails to build:

```
Meson encountered an error in file po/meson.build, line 3, column 0:
Gettext() function has been moved to module i18n. Import it and use i18n.gettext() instead
```

This PR fixes this.

(BTW I have no idea why Github shows line 46 in the README as changed, it's exactly the same.)